### PR TITLE
Use toast notifications in auth flow

### DIFF
--- a/src/components/AuthBar.jsx
+++ b/src/components/AuthBar.jsx
@@ -1,13 +1,16 @@
 // src/components/AuthBar.jsx
 import React, { useState } from "react";
 import { supabase } from "../supabaseClient";
+import { useToast } from "./Toast.jsx";
 
 export default function AuthBar({ session }) {
   const [email, setEmail] = useState("");
+  const { push } = useToast();
 
 // wherever you call signInWithOAuth (e.g., AuthBar.jsx)
 const signInWithGitHub = async () => {
-  const isLocal = location.hostname === "localhost" || location.hostname === "127.0.0.1";
+  const isLocal =
+    location.hostname === "localhost" || location.hostname === "127.0.0.1";
 
   // On GitHub Pages, the app is at /my-english-trainer
   const redirectTo = isLocal
@@ -20,24 +23,28 @@ const signInWithGitHub = async () => {
     provider: "github",
     options: { redirectTo }, // <-- critical
   });
-  if (error) console.error("GitHub sign-in error:", error);
+  if (error) {
+    console.error("GitHub sign-in error:", error);
+    push(`GitHub sign-in error: ${error.message}`, "error");
+  }
 };
 
 const sendMagicLink = async (e) => {
   e.preventDefault();
-  if (!email) return alert("Enter email");
+  if (!email) return push("Enter email", "error");
 
-  const isLocal = location.hostname === "localhost" || location.hostname === "127.0.0.1";
+  const isLocal =
+    location.hostname === "localhost" || location.hostname === "127.0.0.1";
   const emailRedirectTo = isLocal
-    ? location.origin                         // http://localhost:5173
+    ? location.origin // http://localhost:5173
     : `${location.origin}/my-english-trainer`; // https://.../my-english-trainer
 
   const { error } = await supabase.auth.signInWithOtp({
     email,
-    options: { emailRedirectTo },   // <-- critical
+    options: { emailRedirectTo }, // <-- critical
   });
-  if (error) alert(error.message);
-  else alert("Magic link sent. Check your inbox.");
+  if (error) push(error.message, "error");
+  else push("Magic link sent. Check your inbox.", "success");
 };
 
   const signOut = async () => { await supabase.auth.signOut(); };

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -13,6 +13,12 @@ export function ToastProvider({ children }) {
     }, ms);
   };
 
+  const styles = {
+    error: { background: "#fee2e2", color: "#7f1d1d" },
+    success: { background: "#dcfce7", color: "#14532d" },
+    info: { background: "#e0e7ff", color: "#1e3a8a" },
+  };
+
   return (
     <ToastCtx.Provider value={{ push }}>
       {children}
@@ -30,8 +36,7 @@ export function ToastProvider({ children }) {
           <div
             key={i.id}
             style={{
-              background: i.type === "error" ? "#fee2e2" : "#e0e7ff",
-              color: i.type === "error" ? "#7f1d1d" : "#1e3a8a",
+              ...(styles[i.type] || styles.info),
               padding: "10px 12px",
               borderRadius: 10,
               boxShadow: "0 8px 24px rgba(0,0,0,.12)",
@@ -46,6 +51,7 @@ export function ToastProvider({ children }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useToast() {
   return React.useContext(ToastCtx);
 }


### PR DESCRIPTION
## Summary
- extend Toast component with success styling
- replace blocking alerts in AuthBar with toast notifications

## Testing
- `npx eslint src/components/AuthBar.jsx src/components/Toast.jsx`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abc6819bf0832cbebfbced0c508124