### PR TITLE
Consolidate supabase client module

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
 // supabase + auth
-import { supabase } from './supabaseClient';
+import { supabase } from './utils/supabaseClient';
 import AuthBar from './components/AuthBar';
 
 // utils

--- a/src/components/AuthBar.jsx
+++ b/src/components/AuthBar.jsx
@@ -1,6 +1,6 @@
 // src/components/AuthBar.jsx
 import React, { useState } from "react";
-import { supabase } from "../supabaseClient";
+import { supabase } from "../utils/supabaseClient";
 
 export default function AuthBar({ session }) {
   const [email, setEmail] = useState("");

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Statistics from '../components/Statistics.jsx';
 import { getReviewLog } from '../utils/reviews.js';
 import { bus } from '../utils/bus.js';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../utils/supabaseClient';
 import { loadReviews } from '../utils/cloud';
 
 function dedupeByKey(arr, keyFn) {

--- a/src/pages/Words.jsx
+++ b/src/pages/Words.jsx
@@ -6,7 +6,7 @@ import { uid, todayISO, safeLower } from '../utils';
 import { autoTranslate } from '../utils/translator';
 
 // Cloud
-import { supabase } from '../supabaseClient';
+import { supabase } from '../utils/supabaseClient';
 import { loadWords, upsertWord, deleteWord as cloudDeleteWord } from '../utils/cloud';
 
 export default function Words() {

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,6 +1,0 @@
-import { createClient } from "@supabase/supabase-js";
-
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);

--- a/src/utils/cloud.js
+++ b/src/utils/cloud.js
@@ -1,5 +1,5 @@
 // src/utils/cloud.js
-import { supabase } from "../supabaseClient";
+import { supabase } from "./supabaseClient";
 
 /* ------- helpers ------- */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/src/utils/supabaseClient.js
+++ b/src/utils/supabaseClient.js
@@ -1,4 +1,3 @@
-// src/supabaseClient.js
 import { createClient } from "@supabase/supabase-js";
 
 const url = import.meta.env.VITE_SUPABASE_URL;


### PR DESCRIPTION
## Summary
- Remove duplicate Supabase client and keep a single implementation in `src/utils/supabaseClient.js`
- Update all references to import the client from the utilities module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc67c51ac832cbe8132dfaeb33b83